### PR TITLE
Implementing requiresMainQueueSetup

### DIFF
--- a/ios/RNAdMobInterstitial.m
+++ b/ios/RNAdMobInterstitial.m
@@ -30,6 +30,11 @@ static NSString *const kEventAdLeftApplication = @"interstitialAdLeftApplication
 
 RCT_EXPORT_MODULE();
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 - (NSArray<NSString *> *)supportedEvents
 {
     return @[

--- a/ios/RNAdMobRewarded.m
+++ b/ios/RNAdMobRewarded.m
@@ -30,6 +30,11 @@ static NSString *const kEventVideoStarted = @"rewardedVideoAdVideoStarted";
 
 RCT_EXPORT_MODULE();
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 - (NSArray<NSString *> *)supportedEvents
 {
     return @[

--- a/ios/RNDFPBannerViewManager.m
+++ b/ios/RNDFPBannerViewManager.m
@@ -15,6 +15,11 @@
 
 RCT_EXPORT_MODULE();
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 - (UIView *)view
 {
   return [RNDFPBannerView new];

--- a/ios/RNGADBannerViewManager.m
+++ b/ios/RNGADBannerViewManager.m
@@ -16,6 +16,11 @@
 
 RCT_EXPORT_MODULE();
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 - (UIView *)view
 {
     return [RNGADBannerView new];


### PR DESCRIPTION
This will fix the warnings that we are getting like:

Module RNAdMobInterstitial requires main queue setup since it overrides `constantsToExport` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.